### PR TITLE
GH-6: Update Cake references to 0.26

### DIFF
--- a/src/Cake.Apprenda.Tests/Cake.Apprenda.Tests.csproj
+++ b/src/Cake.Apprenda.Tests/Cake.Apprenda.Tests.csproj
@@ -41,11 +41,11 @@
     <CodeAnalysisRuleSet>Cake.Apprenda.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.24.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.24.0\lib\net46\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.26.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Cake.Testing, Version=0.24.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Testing.0.24.0\lib\net46\Cake.Testing.dll</HintPath>
+    <Reference Include="Cake.Testing, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Testing.0.26.0\lib\net46\Cake.Testing.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions, Version=4.19.4.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.4.19.4\lib\net45\FluentAssertions.dll</HintPath>

--- a/src/Cake.Apprenda.Tests/packages.config
+++ b/src/Cake.Apprenda.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.24.0" targetFramework="net461" />
-  <package id="Cake.Testing" version="0.24.0" targetFramework="net461" />
+  <package id="Cake.Core" version="0.26.0" targetFramework="net461" />
+  <package id="Cake.Testing" version="0.26.0" targetFramework="net461" />
   <package id="FluentAssertions" version="4.19.4" targetFramework="net461" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net461" />
   <package id="xunit" version="2.3.1" targetFramework="net461" />

--- a/src/Cake.Apprenda/Cake.Apprenda.csproj
+++ b/src/Cake.Apprenda/Cake.Apprenda.csproj
@@ -39,8 +39,8 @@
     <SourceAnalysisTreatErrorsAsWarnings>False</SourceAnalysisTreatErrorsAsWarnings>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.24.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.24.0\lib\net46\Cake.Core.dll</HintPath>
+    <Reference Include="Cake.Core, Version=0.26.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Cake.Core.0.26.0\lib\net46\Cake.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Cake.Apprenda/packages.config
+++ b/src/Cake.Apprenda/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake.Core" version="0.24.0" targetFramework="net461" developmentDependency="true" />
+  <package id="Cake.Core" version="0.26.0" targetFramework="net461" developmentDependency="true" />
   <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Addresses GH-6, Updates Cake references to 0.26